### PR TITLE
Implement editing for incomes and expenses

### DIFF
--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -52,6 +52,13 @@ export const useStore = defineStore('store', () => {
     incomes.value.push(income)
   }
 
+  const updateIncome = (updatedIncome: IIncome) => {
+    const index = incomes.value.findIndex(i => i.id === updatedIncome.id)
+    if (index !== -1) {
+      incomes.value[index] = updatedIncome
+    }
+  }
+
   const removeIncome = (income: IIncome) => {
     const incomeIndex = incomes.value.findIndex((i) => i.id === income.id)
     incomes.value.splice(incomeIndex, 1)
@@ -59,6 +66,13 @@ export const useStore = defineStore('store', () => {
 
   const addExpense = (expense: IExpense) => {
     expenses.value.push(expense)
+  }
+
+  const updateExpense = (updatedExpense: IExpense) => {
+    const index = expenses.value.findIndex(e => e.id === updatedExpense.id)
+    if (index !== -1) {
+      expenses.value[index] = updatedExpense
+    }
   }
 
   const removeExpense = (expense: IExpense) => {
@@ -94,11 +108,13 @@ export const useStore = defineStore('store', () => {
     years,
     incomes,
     addIncome,
+    updateIncome,
     removeIncome,
     expenseTypes,
     amountTypes,
     expenses,
     addExpense,
+    updateExpense,
     removeExpense,
     debtTypes,
     debts,


### PR DESCRIPTION
## Summary
- add `updateIncome` and `updateExpense` store actions
- enable editing in IncomesView
- enable editing in ExpensesView

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8e3582688321ac230a7b42671585