### PR TITLE
Implement guided tour in summary view

### DIFF
--- a/src/components/AnnualSummary.vue
+++ b/src/components/AnnualSummary.vue
@@ -3,14 +3,23 @@ import type { ICustomDate, INextMonth } from '@/types';
 import { useStore } from '@/stores/store';
 import Divider from 'primevue/divider';
 import AmountItem from '@/components/SummaryTable/AmountItem.vue';
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted, type Ref } from 'vue';
 import { STATIC_PAYMENT_TYPE_VALUE, SUSCRIPTION_PAYMENT_TYPE_VALUE } from '@/constants';
 import { periodIncludesCustomDate, isSameDate, isStatictExpenseOrSuscription } from '@/utils';
 
 const props = defineProps<{
   selectedDate: ICustomDate,
   class?: string,
+  containerRef?: Ref<HTMLElement | null>,
 }>();
+
+const rootElement = ref<HTMLElement | null>(null)
+
+onMounted(() => {
+  if (props.containerRef) {
+    props.containerRef.value = rootElement.value
+  }
+})
 
 const { months, incomes, expenses, debts } = useStore();
 
@@ -100,7 +109,7 @@ const toggleContent = () => {
 </script>
 
 <template>
-  <div :class="props.class">
+  <div :class="props.class" ref="rootElement">
     <button @click="toggleContent" class="grid grid-cols-1 rounded-sm hover:bg-sky-950 hover:text-white p-4 cursor-pointer w-full">
       <div class="text-lg lg:text-xl font-bold grid place-content-start">
         <div>

--- a/src/components/SummaryTable/SummaryTable.vue
+++ b/src/components/SummaryTable/SummaryTable.vue
@@ -3,17 +3,26 @@ import type { IDebt, IExpense, IIncome  } from '@/types';
 import Divider from 'primevue/divider';
 import DataTable from 'primevue/datatable';
 import { PAGINATION_ROWS_PER_PAGE, PAGINATION_OPTIONS } from '@/constants';
-import { ref } from 'vue';
+import { ref, onMounted, type Ref } from 'vue';
 
-const props = defineProps<{
+const props = defineProps<{ 
   sortField: string,
   titleLabel: string,
   subTitleLabel?: string,
   emptyStateLabel: string,
   rows: IIncome[] | IExpense[] | IDebt[],
   class?: string,
-  iconClass?: string
+  iconClass?: string,
+  containerRef?: Ref<HTMLElement | null>
 }>();
+
+const rootElement = ref<HTMLElement | null>(null)
+
+onMounted(() => {
+  if (props.containerRef) {
+    props.containerRef.value = rootElement.value
+  }
+})
 
 const isShowingContent = ref(false);
 
@@ -23,7 +32,7 @@ const toggleContent = () => {
 </script>
 
 <template>
-  <div :class="props.class">
+  <div :class="props.class" ref="rootElement">
     <button @click="toggleContent" class="grid grid-cols-2 rounded-sm hover:bg-sky-950 hover:text-white p-4 cursor-pointer w-full">
       <div class="text-lg lg:text-xl font-bold grid place-content-start">
         <div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,3 +77,5 @@ export const DARK_MODE_STORAGE_KEY = 'dark-mode'
 export const DEBTS_LABEL = 'Deudas'
 
 export const USER_INFO_STORAGE_KEY = 'user-info'
+
+export const SUMMARY_TOUR_STORAGE_KEY = 'summary-tour-seen'

--- a/src/hooks/useTour.ts
+++ b/src/hooks/useTour.ts
@@ -1,0 +1,56 @@
+import { ref, onMounted, Ref } from 'vue'
+
+export interface TourStep {
+  message: string
+  target?: Ref<HTMLElement | null>
+}
+
+export default function useTour(
+  steps: TourStep[],
+  seenRef: Ref<boolean>,
+  markSeen: (value: boolean) => void,
+) {
+  const isTourOpen = ref(false)
+  const tourStep = ref(0)
+  const tourStyle = ref<Record<string, string>>({})
+
+  const showStep = (index: number) => {
+    tourStep.value = index
+    const target = steps[index].target?.value
+    if (target) {
+      const rect = target.getBoundingClientRect()
+      tourStyle.value = {
+        position: 'absolute',
+        top: `${rect.bottom + window.scrollY + 8}px`,
+        left: `${rect.left + window.scrollX}px`,
+      }
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    } else {
+      tourStyle.value = {}
+    }
+  }
+
+  const nextTourStep = () => {
+    if (tourStep.value < steps.length - 1) {
+      showStep(tourStep.value + 1)
+    } else {
+      isTourOpen.value = false
+      markSeen(true)
+    }
+  }
+
+  onMounted(() => {
+    if (!seenRef.value) {
+      isTourOpen.value = true
+      showStep(0)
+    }
+  })
+
+  return {
+    isTourOpen,
+    tourStep,
+    tourStyle,
+    nextTourStep,
+    showStep,
+  }
+}

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -11,7 +11,8 @@ import {
   EXPENSES_LOCAL_STORAGE_KEY,
   DEBT_TYPES,
   DEBTS_LOCAL_STORAGE_KEY,
-  USER_INFO_STORAGE_KEY
+  USER_INFO_STORAGE_KEY,
+  SUMMARY_TOUR_STORAGE_KEY
 } from '@/constants'
 import type {
   IAmountType,
@@ -32,8 +33,9 @@ const END_YEAR = 2034
 export const useStore = defineStore('store', () => {
   const isDarkMode = useStorage<boolean>(DARK_MODE_STORAGE_KEY, false)
   const userInfo = useStorage<IUserInfo>(USER_INFO_STORAGE_KEY, {
-    name: null, 
+    name: null,
   })
+  const summaryTourSeen = useStorage<boolean>(SUMMARY_TOUR_STORAGE_KEY, false)
   const incomeTypes = ref<IIncomeType[]>(INCOME_TYPES)
   const expenseTypes = ref<IExpenseType[]>(EXPENSE_TYPES)
   const amountTypes = ref<IAmountType[]>(AMOUNT_TYPES)
@@ -100,6 +102,10 @@ export const useStore = defineStore('store', () => {
     userInfo.value = user
   }
 
+  const setSummaryTourSeen = (value: boolean) => {
+    summaryTourSeen.value = value
+  }
+
   return {
     isDarkMode,
     setDarkMode,
@@ -122,6 +128,8 @@ export const useStore = defineStore('store', () => {
     updateDebt,
     removeDebt,
     userInfo,
-    setUser
+    setUser,
+    summaryTourSeen,
+    setSummaryTourSeen
   }
 })


### PR DESCRIPTION
## Summary
- add step for annual projection table and anchor tour dialogs near elements
- update guided tour logic with showStep helper and dynamic positions
- refactor: extract guided tour to reusable hook
- expose refs from AnnualSummary and SummaryTable for tour targeting
- guide users through suscripciones, gastos fijos, retiros y deudas

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run type-check` *(fails: vue-tsc not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685c92660f208321ad4e11e9fc7bf88a