### PR TITLE
Open summary tables on load

### DIFF
--- a/src/components/SummaryTable/SummaryTable.vue
+++ b/src/components/SummaryTable/SummaryTable.vue
@@ -5,7 +5,8 @@ import DataTable from 'primevue/datatable';
 import { PAGINATION_ROWS_PER_PAGE, PAGINATION_OPTIONS } from '@/constants';
 import { ref } from 'vue';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
+  initialOpen?: boolean,
   sortField: string,
   titleLabel: string,
   subTitleLabel?: string,
@@ -13,9 +14,11 @@ const props = defineProps<{
   rows: IIncome[] | IExpense[] | IDebt[],
   class?: string,
   iconClass?: string
-}>();
+}>(), {
+  initialOpen: true,
+});
 
-const isShowingContent = ref(true);
+const isShowingContent = ref(props.initialOpen);
 
 const toggleContent = () => {
   isShowingContent.value = !isShowingContent.value;

--- a/src/components/SummaryTable/SummaryTable.vue
+++ b/src/components/SummaryTable/SummaryTable.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
   iconClass?: string
 }>();
 
-const isShowingContent = ref(false);
+const isShowingContent = ref(true);
 
 const toggleContent = () => {
   isShowingContent.value = !isShowingContent.value;

--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -268,7 +268,6 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay ingresos registrados para la fecha seleccionada"
         :rows="incomesToRender"
         :sub-title-label="formatCurrency(totalIncomes)"
-        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -293,7 +292,6 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay suscripciones registradas para la fecha seleccionada"
         :rows="suscriptionsToRender"
         :sub-title-label="formatCurrency(totalSuscriptions)"
-        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -318,7 +316,6 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay gastos registrados para la fecha seleccionada"
         :rows="staticExpensesToRender"
         :sub-title-label="formatCurrency(totalStaticExpenses)"
-        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -343,7 +340,6 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay gastos registrados para la fecha seleccionada"
         :rows="generalExpensesToRender"
         :sub-title-label="formatCurrency(totalGeneralExpenses)"
-        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -368,7 +364,6 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay deudas registradas para la fecha seleccionada"
         :rows="debtsToRender"
         :sub-title-label="formatCurrency(totalDebts)"
-        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>

--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -268,6 +268,7 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay ingresos registrados para la fecha seleccionada"
         :rows="incomesToRender"
         :sub-title-label="formatCurrency(totalIncomes)"
+        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -292,6 +293,7 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay suscripciones registradas para la fecha seleccionada"
         :rows="suscriptionsToRender"
         :sub-title-label="formatCurrency(totalSuscriptions)"
+        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -316,6 +318,7 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay gastos registrados para la fecha seleccionada"
         :rows="staticExpensesToRender"
         :sub-title-label="formatCurrency(totalStaticExpenses)"
+        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -340,6 +343,7 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay gastos registrados para la fecha seleccionada"
         :rows="generalExpensesToRender"
         :sub-title-label="formatCurrency(totalGeneralExpenses)"
+        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>
@@ -364,6 +368,7 @@ const balanceChartData = computed(() => {
         empty-state-label="No hay deudas registradas para la fecha seleccionada"
         :rows="debtsToRender"
         :sub-title-label="formatCurrency(totalDebts)"
+        :initial-open="true"
       >
         <template #columns>
           <Column field="name" header="Concepto" sortable class="w-1/5"/>


### PR DESCRIPTION
## Summary
- keep annual projection collapsed but open all other summary tables by default

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1e34273483219ef6bc65eb89f123