### PR TITLE
Add links to empty states and open modals via query

### DIFF
--- a/src/components/SummaryTable/SummaryTable.vue
+++ b/src/components/SummaryTable/SummaryTable.vue
@@ -1,18 +1,21 @@
 <script setup lang="ts">
-import type { IDebt, IExpense, IIncome  } from '@/types';
+import type { IDebt, IExpense, IIncome } from '@/types';
 import Divider from 'primevue/divider';
 import DataTable from 'primevue/datatable';
 import { PAGINATION_ROWS_PER_PAGE, PAGINATION_OPTIONS } from '@/constants';
 import { ref } from 'vue';
+import { RouterLink } from 'vue-router';
 
 const props = defineProps<{
-  sortField: string,
-  titleLabel: string,
-  subTitleLabel?: string,
-  emptyStateLabel: string,
-  rows: IIncome[] | IExpense[] | IDebt[],
-  class?: string,
-  iconClass?: string
+  sortField: string;
+  titleLabel: string;
+  subTitleLabel?: string;
+  emptyStateLabel: string;
+  rows: IIncome[] | IExpense[] | IDebt[];
+  class?: string;
+  iconClass?: string;
+  emptyStateLink?: import('vue-router').RouteLocationRaw;
+  emptyStateLinkLabel?: string;
 }>();
 
 const isShowingContent = ref(false);
@@ -66,6 +69,13 @@ const toggleContent = () => {
           <span class="text-gray-500 text-lg">
             <i class="pi pi-info-circle" style="font-size: 16px;"></i>
             {{ props.emptyStateLabel }}
+            <RouterLink
+              v-if="props.emptyStateLink && props.emptyStateLinkLabel"
+              :to="props.emptyStateLink"
+              class="text-sky-600 underline ml-1"
+            >
+              {{ props.emptyStateLinkLabel }}
+            </RouterLink>
           </span>
         </div>
       </div>

--- a/src/hooks/useOpenModalFromQuery.ts
+++ b/src/hooks/useOpenModalFromQuery.ts
@@ -1,0 +1,18 @@
+import { onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+export enum Actions {
+  NEW = 'new'
+}
+
+export default function useOpenModalFromQuery(openModal: () => void) {
+  const route = useRoute()
+  const router = useRouter()
+
+  onMounted(() => {
+    if (route.query.action === Actions.NEW) {
+      openModal()
+      router.replace({ query: {} })
+    }
+  })
+}

--- a/src/views/DebtsView.vue
+++ b/src/views/DebtsView.vue
@@ -11,6 +11,7 @@ import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import AmountItem from '@/components/SummaryTable/AmountItem.vue';
 import { computed, ref } from 'vue';
+import useOpenModalFromQuery from '@/hooks/useOpenModalFromQuery';
 import { useStore } from '@/stores/store';
 import { useToast } from "primevue/usetoast";
 import { useConfirm } from "primevue/useconfirm";
@@ -47,6 +48,7 @@ const {
   yearsToRender,
   selectedDate,
 } = useDateFilters()
+
 
 const debtsToRender = computed(() => {
   return debts.filter(debt => {
@@ -85,6 +87,7 @@ const openCreateModal = () => {
   editingDebtId.value = null
   isOpenModal.value = true
 }
+useOpenModalFromQuery(openCreateModal)
 
 const showSuccess = (summary: string, detail: string) => {
   toast.add({ severity: 'success', summary: summary, detail: detail, life: 5000 })

--- a/src/views/ExpensesView.vue
+++ b/src/views/ExpensesView.vue
@@ -11,6 +11,7 @@ import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import AmountItem from '@/components/SummaryTable/AmountItem.vue';
 import { computed, ref } from 'vue';
+import useOpenModalFromQuery from '@/hooks/useOpenModalFromQuery';
 import { useStore } from '@/stores/store';
 import { useToast } from "primevue/usetoast";
 import { useConfirm } from "primevue/useconfirm";
@@ -51,6 +52,7 @@ const {
   yearsToRender,
 } = useDateFilters()
 
+
 const modalHeader = computed(() => isEditMode.value ? 'Editar Gasto' : 'Nuevo Gasto')
 
 const isOpenModal = ref(false)
@@ -87,6 +89,7 @@ const openCreateModal = () => {
   editingExpenseId.value = null
   isOpenModal.value = true
 }
+useOpenModalFromQuery(openCreateModal)
 
 const showSuccess = (summary: string, detail: string) => {
   toast.add({ severity: 'success', summary: summary, detail: detail, life: 5000 })

--- a/src/views/IncomesView.vue
+++ b/src/views/IncomesView.vue
@@ -11,6 +11,7 @@ import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import AmountItem from '@/components/SummaryTable/AmountItem.vue';
 import { computed, ref } from 'vue';
+import useOpenModalFromQuery from '@/hooks/useOpenModalFromQuery';
 import { useStore } from '@/stores/store';
 import { useToast } from "primevue/usetoast";
 import { useConfirm } from "primevue/useconfirm";
@@ -50,6 +51,7 @@ const {
   selectedDate,
 } = useDateFilters()
 
+
 const incomesToRender = computed(() => {
   return incomes.filter(income => {
     const isInIncomePeriod = periodIncludesCustomDate({
@@ -81,6 +83,7 @@ const openCreateModal = () => {
   editingIncomeId.value = null
   isOpenModal.value = true
 }
+useOpenModalFromQuery(openCreateModal)
 
 const showSuccess = (summary: string, detail: string) => {
   toast.add({ severity: 'success', summary: summary, detail: detail, life: 5000 })

--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { DEBTS_LABEL, STATIC_PAYMENT_TYPE_VALUE, SUSCRIPTION_PAYMENT_TYPE_VALUE } from '@/constants';
 import { useStore } from '@/stores/store';
+import { Actions } from '@/hooks/useOpenModalFromQuery';
 import type { ICustomDate, IMonth, IYear, Month } from '@/types';
 import Card from 'primevue/card';
 import Divider from 'primevue/divider';
@@ -266,6 +267,8 @@ const balanceChartData = computed(() => {
         sort-field="amount"
         title-label="Ingresos"
         empty-state-label="No hay ingresos registrados para la fecha seleccionada"
+        :empty-state-link="{ name: 'incomes', query: { action: Actions.NEW } }"
+        empty-state-link-label="Registrar ingreso"
         :rows="incomesToRender"
         :sub-title-label="formatCurrency(totalIncomes)"
       >
@@ -290,6 +293,8 @@ const balanceChartData = computed(() => {
         sort-field="amount"
         title-label="Suscripciones"
         empty-state-label="No hay suscripciones registradas para la fecha seleccionada"
+        :empty-state-link="{ name: 'expenses', query: { action: Actions.NEW } }"
+        empty-state-link-label="Registrar gasto"
         :rows="suscriptionsToRender"
         :sub-title-label="formatCurrency(totalSuscriptions)"
       >
@@ -314,6 +319,8 @@ const balanceChartData = computed(() => {
         sort-field="amount"
         title-label="Gastos fijos"
         empty-state-label="No hay gastos registrados para la fecha seleccionada"
+        :empty-state-link="{ name: 'expenses', query: { action: Actions.NEW } }"
+        empty-state-link-label="Registrar gasto"
         :rows="staticExpensesToRender"
         :sub-title-label="formatCurrency(totalStaticExpenses)"
       >
@@ -338,6 +345,8 @@ const balanceChartData = computed(() => {
         sort-field="amount"
         title-label="Retiros y otros gastos"
         empty-state-label="No hay gastos registrados para la fecha seleccionada"
+        :empty-state-link="{ name: 'expenses', query: { action: Actions.NEW } }"
+        empty-state-link-label="Registrar gasto"
         :rows="generalExpensesToRender"
         :sub-title-label="formatCurrency(totalGeneralExpenses)"
       >
@@ -362,6 +371,8 @@ const balanceChartData = computed(() => {
         sort-field="amount"
         title-label="Deudas"
         empty-state-label="No hay deudas registradas para la fecha seleccionada"
+        :empty-state-link="{ name: 'debts', query: { action: Actions.NEW } }"
+        empty-state-link-label="Registrar deuda"
         :rows="debtsToRender"
         :sub-title-label="formatCurrency(totalDebts)"
       >


### PR DESCRIPTION
## Summary
- add optional `emptyStateLink` for SummaryTable to display router link
- wire `SummaryView` empty states to proper pages
- open form modals automatically from query params
- refactor repeated modal-opening logic into `useOpenModalFromQuery`
- use `Actions` enum for query values and clean extra line breaks

## Testing
- `npm run lint` *(fails: jiti missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f214066d883219dd9e75ccfd8a6b9