### PR TITLE
Add language selection with vue-i18n

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare module 'vue-i18n'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "primevue": "^4.3.1",
     "tailwindcss": "^4.0.9",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "vue-i18n": "^11.0.0"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,14 +3,17 @@ import { RouterLink, RouterView, useRoute } from 'vue-router'
 import ToggleSwitch from 'primevue/toggleswitch'
 import Dialog from 'primevue/dialog';
 import InputText from 'primevue/inputtext';
+import Select from 'primevue/select';
 import { onMounted, ref, watch } from 'vue'
 import { useStore } from '@/stores/store'
 import { DARK_MODE_STORAGE_KEY } from '@/constants'
+import useLocale from '@/hooks/useLocale'
 
 const { isDarkMode: defaultDarkMode, setDarkMode, userInfo, setUser } = useStore()
 const isDarkMode = ref(defaultDarkMode)
 const route = useRoute()
 const userName = ref('')
+const { t, locale, localeOptions } = useLocale()
 
 const toggleDarkModeClass = () => {
   document.documentElement.classList.toggle(DARK_MODE_STORAGE_KEY)
@@ -24,6 +27,7 @@ const toggleDarkMode = () =>{
 watch(isDarkMode, () => {
   toggleDarkMode()
 })
+
 
 onMounted(() => {
   if (defaultDarkMode) {
@@ -57,24 +61,25 @@ const saveUserName = () => {
           </div>
 
           <div class="absolute top-3 right-2 lg:right-auto lg:top-auto lg:bottom-25 lg:left-24 grid grid-flow-col lg:grid-flow-row lg:mt-5 place-items-center gap-2 lg:gap-3">
+            <Select v-model="locale" :options="localeOptions" optionLabel="label" class="w-20" />
             <div class="text-xs font-bold">
-              <span class="hidden lg:inline-block">Modo Oscuro </span> <i :class="isDarkMode ? 'pi pi-sun' : 'pi pi-moon'"></i>
+              <span class="hidden lg:inline-block">{{ t('darkMode') }} </span> <i :class="isDarkMode ? 'pi pi-sun' : 'pi pi-moon'"></i>
             </div>
             <ToggleSwitch v-model="isDarkMode" />
           </div>
 
           <nav class="grid h-16 text-sm lg:text-base lg:px-0 px-4 grid-flow-col lg:grid-flow-row place-items-center gap-3 font-bold">
             <RouterLink to="/">
-              <i class="pi pi-chart-line" :style="{fontSize: '14px'}"></i> Resumen
+              <i class="pi pi-chart-line" :style="{fontSize: '14px'}"></i> {{ t('navigation.summary') }}
             </RouterLink>
             <RouterLink to="/incomes">
-              <i class="pi pi-dollar" :style="{fontSize: '14px'}"></i> Ingresos
+              <i class="pi pi-dollar" :style="{fontSize: '14px'}"></i> {{ t('navigation.incomes') }}
             </RouterLink>
             <RouterLink to="/expenses">
-              <i class="pi pi-wallet" :style="{fontSize: '14px'}"></i> Gastos
+              <i class="pi pi-wallet" :style="{fontSize: '14px'}"></i> {{ t('navigation.expenses') }}
             </RouterLink>
             <RouterLink to="/debts">
-              <i class="pi pi-credit-card" :style="{fontSize: '14px'}"></i> Deudas
+              <i class="pi pi-credit-card" :style="{fontSize: '14px'}"></i> {{ t('navigation.debts') }}
             </RouterLink>
           </nav>
 
@@ -89,7 +94,7 @@ const saveUserName = () => {
     </template>
     <template v-else>
       <div class="bg-zinc-900 w-full h-full">
-        <Dialog visible modal header="Bienvenido!" class="w-lg" :draggable="false" :closable="false">
+        <Dialog visible modal :header="t('welcome')" class="w-lg" :draggable="false" :closable="false">
           <p class="text-surface-500 dark:text-surface-400 mb-4">
             Balancash es tu asistente para controlar tus finanzas. Registra ingresos, gastos y deudas de forma sencilla, organízalos por categorías y revisa gráficas que muestran la evolución de tu dinero. Con un balance siempre actualizado, podrás tomar mejores decisiones y alcanzar tus metas financieras.
           </p>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,9 @@ export const DEBTS_LOCAL_STORAGE_KEY = 'debts'
 
 export const DARK_MODE_STORAGE_KEY = 'dark-mode'
 
+export const LOCALE_STORAGE_KEY = 'locale'
+
+
 export const DEBTS_LABEL = 'Deudas'
 
 export const USER_INFO_STORAGE_KEY = 'user-info'

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -1,0 +1,25 @@
+import { useI18n } from 'vue-i18n'
+import { watch } from 'vue'
+import { useStore } from '@/stores/store'
+
+export default function useLocale() {
+  const { locale: storeLocale, setLocale } = useStore()
+  const { t, locale } = useI18n()
+
+  watch(storeLocale, (value) => {
+    locale.value = value
+  }, { immediate: true })
+
+  watch(locale, (value) => {
+    if (storeLocale.value !== value) {
+      setLocale(value)
+    }
+  })
+
+  const localeOptions = [
+    { label: 'Español', value: 'es' },
+    { label: 'English', value: 'en' }
+  ]
+
+  return { t, locale: storeLocale, localeOptions }
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,15 @@
+import { createI18n } from 'vue-i18n'
+import es from './locales/es'
+import en from './locales/en'
+import { LOCALE_STORAGE_KEY } from './constants'
+
+const savedLocale = localStorage.getItem(LOCALE_STORAGE_KEY) || 'es'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: savedLocale,
+  fallbackLocale: 'es',
+  messages: { es, en }
+})
+
+export default i18n

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,11 @@
+export default {
+  navigation: {
+    summary: 'Summary',
+    incomes: 'Incomes',
+    expenses: 'Expenses',
+    debts: 'Debts'
+  },
+  darkMode: 'Dark Mode',
+  language: 'Language',
+  welcome: 'Welcome!'
+}

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,0 +1,11 @@
+export default {
+  navigation: {
+    summary: 'Resumen',
+    incomes: 'Ingresos',
+    expenses: 'Gastos',
+    debts: 'Deudas'
+  },
+  darkMode: 'Modo Oscuro',
+  language: 'Idioma',
+  welcome: 'Bienvenido!'
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import Aura from '@primeuix/themes/aura';
 import Button from "primevue/button"
 import ToastService from 'primevue/toastservice';
 import ConfirmationService from 'primevue/confirmationservice';
+import i18n from './i18n'
 
 import App from './App.vue'
 import router from './router'
@@ -15,6 +16,7 @@ const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
+app.use(i18n)
 app.use(PrimeVue, {
   theme: {
     preset: Aura,

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -11,7 +11,8 @@ import {
   EXPENSES_LOCAL_STORAGE_KEY,
   DEBT_TYPES,
   DEBTS_LOCAL_STORAGE_KEY,
-  USER_INFO_STORAGE_KEY
+  USER_INFO_STORAGE_KEY,
+  LOCALE_STORAGE_KEY
 } from '@/constants'
 import type {
   IAmountType,
@@ -31,8 +32,9 @@ const END_YEAR = 2034
 
 export const useStore = defineStore('store', () => {
   const isDarkMode = useStorage<boolean>(DARK_MODE_STORAGE_KEY, false)
+  const locale = useStorage<string>(LOCALE_STORAGE_KEY, 'es')
   const userInfo = useStorage<IUserInfo>(USER_INFO_STORAGE_KEY, {
-    name: null, 
+    name: null,
   })
   const incomeTypes = ref<IIncomeType[]>(INCOME_TYPES)
   const expenseTypes = ref<IExpenseType[]>(EXPENSE_TYPES)
@@ -46,6 +48,10 @@ export const useStore = defineStore('store', () => {
 
   const setDarkMode = (value: boolean) => {
     isDarkMode.value = value
+  }
+
+  const setLocale = (value: string) => {
+    locale.value = value
   }
 
   const addIncome = (income: IIncome) => {
@@ -122,6 +128,8 @@ export const useStore = defineStore('store', () => {
     updateDebt,
     removeDebt,
     userInfo,
-    setUser
+    setUser,
+    locale,
+    setLocale
   }
 })


### PR DESCRIPTION
## Summary
- add locale store key
- move locale handling into a reusable hook
- sync language selection with the global store
- move `LOCALE_STORAGE_KEY` to `constants.ts`

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c106655883218a9dfd4a59e04952