### PR TITLE
feat: add search filters to financial views

### DIFF
--- a/src/hooks/useSearchFilter.ts
+++ b/src/hooks/useSearchFilter.ts
@@ -1,0 +1,21 @@
+import { ref, computed, type Ref } from 'vue'
+
+export default function useSearchFilter<T>(items: Ref<T[]>) {
+  const searchText = ref('')
+
+  const filteredItems = computed(() => {
+    if (!searchText.value) {
+      return items.value
+    }
+
+    const term = searchText.value.toLowerCase()
+    return items.value.filter(item => {
+      return JSON.stringify(item).toLowerCase().includes(term)
+    })
+  })
+
+  return {
+    searchText,
+    filteredItems,
+  }
+}

--- a/src/views/DebtsView.vue
+++ b/src/views/DebtsView.vue
@@ -27,6 +27,7 @@ import type {
   ICustomDate
 } from '@/types';
 import useDateFilters from '@/hooks/useDateFilters';
+import useSearchFilter from '@/hooks/useSearchFilter';
 
 const toast = useToast()
 const confirm = useConfirm()
@@ -64,6 +65,8 @@ const debtsToRender = computed(() => {
     }
   })
 })
+
+const { searchText, filteredItems: filteredDebts } = useSearchFilter(debtsToRender)
 
 const modalHeader = computed(() => isEditMode.value ? 'Editar Deuda' : 'Nueva Deuda')
 
@@ -154,7 +157,7 @@ const save = () => {
     return
   }
 
-  let newDebt: IDebt = {
+  const newDebt: IDebt = {
     id: isEditMode.value && editingDebtId.value ? editingDebtId.value : Math.random().toString(36).substring(2, 9),
     type: debtType.value,
     name: debtName.value,
@@ -195,8 +198,9 @@ const save = () => {
   </div>
 
   <Divider />
-  
-  <div class="grid place-content-end items-center mb-4 grid-flow-col gap-2">
+
+  <div class="grid grid-flow-col items-center mb-4 gap-2">
+    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
     <div>
       <Button label="Nueva Deuda" icon="pi pi-plus" @click="openCreateModal" />
     </div>
@@ -204,8 +208,8 @@ const save = () => {
 
   <div class="mb-4">
     <DataTable
-      v-if="debtsToRender.length > 0"
-      :value="debtsToRender"
+      v-if="filteredDebts.length > 0"
+      :value="filteredDebts"
       tableStyle="min-width: 50rem"
       stripedRows
       :sort-order="-1"
@@ -233,7 +237,7 @@ const save = () => {
         </template>
       </Column>
       <Column>
-        <template #body="slotProps"">
+        <template #body="slotProps">
           <div class="flex gap-2">
             <Button icon="pi pi-pencil" outlined rounded severity="info" @click="edit(slotProps.data)" />
             <Button icon="pi pi-trash" outlined rounded severity="danger" @click="remove(slotProps.data)" />

--- a/src/views/ExpensesView.vue
+++ b/src/views/ExpensesView.vue
@@ -30,6 +30,7 @@ import type {
   IAmountType,
 } from '@/types';
 import useDateFilters from '@/hooks/useDateFilters';
+import useSearchFilter from '@/hooks/useSearchFilter';
 
 const toast = useToast()
 const confirm = useConfirm()
@@ -76,6 +77,8 @@ const allExpensesToRender = computed(() => {
     return isStaticPaymentType || isInSelectedDate
   })
 })
+
+const { searchText, filteredItems: filteredExpenses } = useSearchFilter(allExpensesToRender)
 
 const isStaticPaymentType = computed(() => {
   return expenseType.value?.value === STATIC_PAYMENT_TYPE_VALUE || expenseType.value?.value === SUSCRIPTION_PAYMENT_TYPE_VALUE
@@ -213,7 +216,8 @@ const save = () => {
 
   <Divider />
   
-  <div class="grid place-content-end items-center mb-4 grid-flow-col gap-2">
+  <div class="grid grid-flow-col items-center mb-4 gap-2">
+    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
     <div>
       <Button label="Nuevo Gasto" icon="pi pi-plus" @click="openCreateModal" />
     </div>
@@ -221,8 +225,8 @@ const save = () => {
 
   <div class="mb-4">
     <DataTable
-      v-if="allExpensesToRender.length > 0"
-      :value="allExpensesToRender"
+      v-if="filteredExpenses.length > 0"
+      :value="filteredExpenses"
       tableStyle="min-width: 50rem"
       stripedRows
       :sort-order="-1"
@@ -246,7 +250,7 @@ const save = () => {
         </template>
       </Column>
       <Column>
-        <template #body="slotProps"">
+        <template #body="slotProps">
           <div class="flex gap-2">
             <Button icon="pi pi-pencil" outlined rounded severity="info" @click="edit(slotProps.data)" />
             <Button icon="pi pi-trash" outlined rounded severity="danger" @click="remove(slotProps.data)" />

--- a/src/views/IncomesView.vue
+++ b/src/views/IncomesView.vue
@@ -29,6 +29,7 @@ import type {
   ICustomDate
 } from '@/types';
 import useDateFilters from '@/hooks/useDateFilters';
+import useSearchFilter from '@/hooks/useSearchFilter';
 
 const toast = useToast()
 const confirm = useConfirm()
@@ -60,6 +61,8 @@ const incomesToRender = computed(() => {
     return income.type?.value === STATIC_PAYMENT_TYPE_VALUE || isInIncomePeriod
   })
 })
+
+const { searchText, filteredItems: filteredIncomes } = useSearchFilter(incomesToRender)
 
 const modalHeader = computed(() => isEditMode.value ? 'Editar Ingreso' : 'Nuevo Ingreso')
 
@@ -202,15 +205,16 @@ const save = () => {
   </div>
 
   <Divider />
-  
-  <div class="grid place-content-end mb-4">
+
+  <div class="grid grid-flow-col items-center mb-4 gap-2">
+    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
     <Button label="Nuevo Ingreso" icon="pi pi-plus" @click="openCreateModal" />
   </div>
 
   <div class="mb-4">
     <DataTable
-      v-if="incomesToRender.length > 0"
-      :value="incomesToRender"
+      v-if="filteredIncomes.length > 0"
+      :value="filteredIncomes"
       tableStyle="min-width: 50rem"
       stripedRows
       :sort-order="-1"
@@ -238,7 +242,7 @@ const save = () => {
         </template>
       </Column>
       <Column>
-        <template #body="slotProps"">
+        <template #body="slotProps">
           <div class="flex gap-2">
             <Button icon="pi pi-pencil" outlined rounded severity="info" @click="edit(slotProps.data)" />
             <Button icon="pi pi-trash" outlined rounded severity="danger" @click="remove(slotProps.data)" />


### PR DESCRIPTION
## Summary
- extract generic JSON search filtering into `useSearchFilter` hook
- simplify debts, expenses, and incomes views to reuse the new hook

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: existing repo lint errors)
- `npx eslint src/views/ExpensesView.vue src/views/IncomesView.vue src/views/DebtsView.vue src/hooks/useSearchFilter.ts --fix`


------
https://chatgpt.com/codex/tasks/task_e_68c39c01aae48321816af1b80d4623b4