### PR TITLE
Add paid-item tracking and persistence to summary view

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,3 +77,5 @@ export const DARK_MODE_STORAGE_KEY = 'dark-mode'
 export const DEBTS_LABEL = 'Deudas'
 
 export const USER_INFO_STORAGE_KEY = 'user-info'
+
+export const PAID_ITEMS_STORAGE_KEY = 'paid-items'

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,11 @@ export enum Month {
   DECEMBER = 12,
 }
 
+export enum ItemType {
+  EXPENSE = 'expense',
+  DEBT = 'debt',
+}
+
 export interface IListOption {
   value: number;
   label: string;

--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { DEBTS_LABEL, STATIC_PAYMENT_TYPE_VALUE, SUSCRIPTION_PAYMENT_TYPE_VALUE } from '@/constants';
+import { DEBTS_LABEL, PAID_ITEMS_STORAGE_KEY, STATIC_PAYMENT_TYPE_VALUE, SUSCRIPTION_PAYMENT_TYPE_VALUE } from '@/constants';
 import { useStore } from '@/stores/store';
-import type { ICustomDate, IMonth, IYear, Month } from '@/types';
+import { ItemType, type ICustomDate, type IMonth, type IYear, type Month } from '@/types';
 import Card from 'primevue/card';
 import Divider from 'primevue/divider';
 import Select from 'primevue/select';
+import Checkbox from 'primevue/checkbox';
 import Chart from 'primevue/chart';
 import Column from 'primevue/column';
 import { computed, ref } from 'vue';
+import { useStorage } from '@vueuse/core';
 import AmountCard from '@/components/AmountCard.vue';
 import SummaryTable from '@/components/SummaryTable/SummaryTable.vue';
 import AmountItem from '@/components/SummaryTable/AmountItem.vue';
@@ -26,6 +28,40 @@ const monthsToRender = months.filter(month => month.value >= currentMonth - 1)
 const yearsToRender = years.filter(year => year.value >= currentYear)
 
 const selectedDate = computed<ICustomDate>(() => ({ month: selectedMonth.value?.value as Month, year: selectedYear.value?.value }))
+const paidItems = useStorage<Record<string, boolean>>(PAID_ITEMS_STORAGE_KEY, {})
+
+const getPaidItemKey = (itemId: string, itemType: ItemType) => {
+  return `${itemType}:${itemId}:${selectedDate.value.year}-${selectedDate.value.month}`
+}
+
+const isItemPaid = (itemId: string, itemType: ItemType) => {
+  return Boolean(paidItems.value[getPaidItemKey(itemId, itemType)])
+}
+
+const toggleItemPaid = (itemId: string, itemType: ItemType, isChecked: boolean) => {
+  paidItems.value = {
+    ...paidItems.value,
+    [getPaidItemKey(itemId, itemType)]: isChecked,
+  }
+}
+
+const areAllItemsPaid = (items: { id: string }[], itemType: ItemType) => {
+  return items.length > 0 && items.every(item => isItemPaid(item.id, itemType))
+}
+
+const areSomeItemsPaid = (items: { id: string }[], itemType: ItemType) => {
+  return items.some(item => isItemPaid(item.id, itemType))
+}
+
+const toggleAllItemsPaid = (items: { id: string }[], itemType: ItemType, isChecked: boolean) => {
+  const updatedPaidItems = { ...paidItems.value }
+
+  items.forEach(item => {
+    updatedPaidItems[getPaidItemKey(item.id, itemType)] = isChecked
+  })
+
+  paidItems.value = updatedPaidItems
+}
 
 const generalExpensesToRender = computed(() => {
   return expenses.filter(expense => {
@@ -111,6 +147,22 @@ const totalALLExpenses = computed(() => {
 
 const totalToPay = computed<number>(() => {
   return totalDebts.value + totalALLExpenses.value
+})
+
+const totalPaid = computed(() => {
+  const paidExpenses = allExpensesToRender.value
+    .filter(expense => isItemPaid(expense.id, ItemType.EXPENSE))
+    .reduce((acc, expense) => acc + expense.amount, 0)
+
+  const paidDebts = debtsToRender.value
+    .filter(debt => isItemPaid(debt.id, ItemType.DEBT))
+    .reduce((acc, debt) => acc + debt.amount, 0)
+
+  return paidExpenses + paidDebts
+})
+
+const totalPending = computed(() => {
+  return Math.max(totalToPay.value - totalPaid.value, 0)
 })
 
 const totalToSave = computed(() => {
@@ -251,6 +303,24 @@ const balanceChartData = computed(() => {
         </Card>
       </div>
 
+      <div class="grid lg:grid-cols-2 gap-4 mt-5">
+        <AmountCard
+          :amount="totalPaid"
+          label="Monto Pagado"
+          icon-class="pi-check-circle"
+          :date="selectedDate"
+          label-class="text-green-600"
+        />
+
+        <AmountCard
+          :amount="totalPending"
+          label="Monto Faltante"
+          icon-class="pi-clock"
+          :date="selectedDate"
+          :label-class="totalPending > 0 ? 'text-red-600' : 'text-green-600'"
+        />
+      </div>
+
       <Divider />
 
       <AnnualSummary
@@ -301,7 +371,28 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column />
+          <Column field="id" header="Pagado" class="w-1/5">
+            <template #header>
+              <div class="flex items-center justify-end gap-2 w-full pr-2">
+                <span>Pagado</span>
+                <Checkbox
+                  :binary="true"
+                  :model-value="areAllItemsPaid(suscriptionsToRender, ItemType.EXPENSE)"
+                  :indeterminate="areSomeItemsPaid(suscriptionsToRender, ItemType.EXPENSE) && !areAllItemsPaid(suscriptionsToRender, ItemType.EXPENSE)"
+                  @update:model-value="(value) => toggleAllItemsPaid(suscriptionsToRender, ItemType.EXPENSE, Boolean(value))"
+                />
+              </div>
+            </template>
+            <template #body="slotProps">
+              <div class="flex justify-end w-full pr-2">
+                <Checkbox
+                  :binary="true"
+                  :model-value="isItemPaid(slotProps.data.id, ItemType.EXPENSE)"
+                  @update:model-value="(value) => toggleItemPaid(slotProps.data.id, ItemType.EXPENSE, Boolean(value))"
+                />
+              </div>
+            </template>
+          </Column>
           <Column />
         </template>
       </SummaryTable>
@@ -325,7 +416,28 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column />
+          <Column field="id" header="Pagado" class="w-1/5">
+            <template #header>
+              <div class="flex items-center justify-end gap-2 w-full pr-2">
+                <span>Pagado</span>
+                <Checkbox
+                  :binary="true"
+                  :model-value="areAllItemsPaid(staticExpensesToRender, ItemType.EXPENSE)"
+                  :indeterminate="areSomeItemsPaid(staticExpensesToRender, ItemType.EXPENSE) && !areAllItemsPaid(staticExpensesToRender, ItemType.EXPENSE)"
+                  @update:model-value="(value) => toggleAllItemsPaid(staticExpensesToRender, ItemType.EXPENSE, Boolean(value))"
+                />
+              </div>
+            </template>
+            <template #body="slotProps">
+              <div class="flex justify-end w-full pr-2">
+                <Checkbox
+                  :binary="true"
+                  :model-value="isItemPaid(slotProps.data.id, ItemType.EXPENSE)"
+                  @update:model-value="(value) => toggleItemPaid(slotProps.data.id, ItemType.EXPENSE, Boolean(value))"
+                />
+              </div>
+            </template>
+          </Column>
           <Column />
         </template>
       </SummaryTable>
@@ -349,7 +461,28 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column />
+          <Column field="id" header="Pagado" class="w-1/5">
+            <template #header>
+              <div class="flex items-center justify-end gap-2 w-full pr-2">
+                <span>Pagado</span>
+                <Checkbox
+                  :binary="true"
+                  :model-value="areAllItemsPaid(generalExpensesToRender, ItemType.EXPENSE)"
+                  :indeterminate="areSomeItemsPaid(generalExpensesToRender, ItemType.EXPENSE) && !areAllItemsPaid(generalExpensesToRender, ItemType.EXPENSE)"
+                  @update:model-value="(value) => toggleAllItemsPaid(generalExpensesToRender, ItemType.EXPENSE, Boolean(value))"
+                />
+              </div>
+            </template>
+            <template #body="slotProps">
+              <div class="flex justify-end w-full pr-2">
+                <Checkbox
+                  :binary="true"
+                  :model-value="isItemPaid(slotProps.data.id, ItemType.EXPENSE)"
+                  @update:model-value="(value) => toggleItemPaid(slotProps.data.id, ItemType.EXPENSE, Boolean(value))"
+                />
+              </div>
+            </template>
+          </Column>
           <Column />
         </template>
       </SummaryTable>
@@ -381,6 +514,28 @@ const balanceChartData = computed(() => {
           <Column field="remainingAmountToPay" header="Monto restante" sortable class="w-1/5">
             <template #body="slotProps">
               <AmountItem :amount="slotProps.data.remainingAmountToPay" is-currency />
+            </template>
+          </Column>
+          <Column field="id" header="Pagado" class="w-1/5">
+            <template #header>
+              <div class="flex items-center justify-end gap-2 w-full pr-2">
+                <span>Pagado</span>
+                <Checkbox
+                  :binary="true"
+                  :model-value="areAllItemsPaid(debtsToRender, ItemType.DEBT)"
+                  :indeterminate="areSomeItemsPaid(debtsToRender, ItemType.DEBT) && !areAllItemsPaid(debtsToRender, ItemType.DEBT)"
+                  @update:model-value="(value) => toggleAllItemsPaid(debtsToRender, ItemType.DEBT, Boolean(value))"
+                />
+              </div>
+            </template>
+            <template #body="slotProps">
+              <div class="flex justify-end w-full pr-2">
+                <Checkbox
+                  :binary="true"
+                  :model-value="isItemPaid(slotProps.data.id, ItemType.DEBT)"
+                  @update:model-value="(value) => toggleItemPaid(slotProps.data.id, ItemType.DEBT, Boolean(value))"
+                />
+              </div>
             </template>
           </Column>
         </template>


### PR DESCRIPTION
### Motivation
- Provide a way for users to mark expenses and debts as paid for a selected month/year and persist that state across sessions.
- Surface paid vs pending totals in the summary to help users track payments against their totals.

### Description
- Added `PAID_ITEMS_STORAGE_KEY` in `src/constants.ts` and a new `ItemType` enum in `src/types.ts` to classify paid items as `expense` or `debt`.
- Introduced persistent paid-item storage in `SummaryView.vue` using `useStorage` keyed by `PAID_ITEMS_STORAGE_KEY` and implemented helpers `getPaidItemKey`, `isItemPaid`, `toggleItemPaid`, `areAllItemsPaid`, `areSomeItemsPaid`, and `toggleAllItemsPaid` to manage state per item and selected date.
- Added column-level and row-level `Checkbox` controls to the subscriptions, static expenses, general expenses, and debts tables to toggle paid state (including header master checkbox with indeterminate support).
- Computed `totalPaid` and `totalPending` values and added two `AmountCard` components to display the paid and pending amounts in the summary UI.

### Testing
- Ran the existing test suite with `npm run test` and linting via `npm run lint`, and both completed successfully.
- Performed a local build with `npm run build` to ensure templates and imports compile without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a1f9c6808321a28b3c0c85b6aab2)