### PR TITLE
Fix column layout and duplicate headers in SummaryView.vue

### DIFF
--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -347,8 +347,6 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column />
-          <Column />
         </template>
       </SummaryTable>
 
@@ -371,7 +369,8 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column field="id" header="Pagado" class="w-1/5">
+          <Column />
+          <Column field="id" class="w-1/5">
             <template #header>
               <div class="flex items-center justify-end gap-2 w-full">
                 <span>Pagado</span>
@@ -393,7 +392,6 @@ const balanceChartData = computed(() => {
               </div>
             </template>
           </Column>
-          <Column />
         </template>
       </SummaryTable>
 
@@ -416,7 +414,8 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column field="id" header="Pagado" class="w-1/5">
+          <Column />
+          <Column field="id" class="w-1/5">
             <template #header>
               <div class="flex items-center justify-end gap-2 w-full">
                 <span>Pagado</span>
@@ -438,7 +437,6 @@ const balanceChartData = computed(() => {
               </div>
             </template>
           </Column>
-          <Column />
         </template>
       </SummaryTable>
 
@@ -461,7 +459,8 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.amount" is-currency />
             </template>
           </Column>
-          <Column field="id" header="Pagado" class="w-1/5">
+          <Column />
+          <Column field="id" class="w-1/5">
             <template #header>
               <div class="flex items-center justify-end gap-2 w-full">
                 <span>Pagado</span>
@@ -483,7 +482,6 @@ const balanceChartData = computed(() => {
               </div>
             </template>
           </Column>
-          <Column />
         </template>
       </SummaryTable>
 
@@ -516,7 +514,7 @@ const balanceChartData = computed(() => {
               <AmountItem :amount="slotProps.data.remainingAmountToPay" is-currency />
             </template>
           </Column>
-          <Column field="id" header="Pagado" class="w-1/5">
+          <Column field="id" class="w-1/5">
             <template #header>
               <div class="flex items-center justify-end gap-2 w-full">
                 <span>Pagado</span>


### PR DESCRIPTION
### Motivation
- Ensure consistent column alignment across all `SummaryTable` instances in the summary view. 
- Remove redundant `header` attributes that conflicted with custom header templates containing the checkbox controls.

### Description
- Updated `src/views/SummaryView.vue` to add a placeholder `<Column />` before the paid-checkbox column in subscription, static expenses, and general expenses tables to align columns consistently. 
- Removed the `header` attribute from the `Column` that renders the paid-checkbox so the header content is provided exclusively by the existing header templates. 
- Removed two unused/empty `<Column />` entries from the incomes table to clean up the columns definition.

### Testing
- Ran `npm run lint` to validate formatting and static analysis and it completed successfully. 
- Ran `npm test` to execute the project's automated test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b01484308321bd85d9c55d5ce91f)