### PR TITLE
Corregir inserción de gasto futuro al reutilizar prioridad

### DIFF
--- a/src/views/FutureExpensesView.vue
+++ b/src/views/FutureExpensesView.vue
@@ -21,7 +21,6 @@ const toast = useToast()
 const confirm = useConfirm()
 const {
   futureExpenses,
-  addFutureExpense,
   updateFutureExpense,
   removeFutureExpense,
   setFutureExpenses,
@@ -62,6 +61,28 @@ const normalizePriorities = (items: IFutureExpense[]) => {
   return [...items]
     .sort((a, b) => a.priority - b.priority)
     .map((item, index) => ({ ...item, priority: index + 1 }))
+}
+
+const getPriorityBounded = (priority: number, maxPriority: number) => {
+  return Math.max(1, Math.min(priority, maxPriority))
+}
+
+const insertFutureExpenseWithPriority = (items: IFutureExpense[], newItem: IFutureExpense) => {
+  const boundedPriority = getPriorityBounded(newItem.priority, items.length + 1)
+  const shiftedItems = items.map((item) => {
+    if (item.priority >= boundedPriority) {
+      return { ...item, priority: item.priority + 1 }
+    }
+    return { ...item }
+  })
+
+  return normalizePriorities([
+    ...shiftedItems,
+    {
+      ...newItem,
+      priority: boundedPriority,
+    },
+  ])
 }
 
 const clearForm = () => {
@@ -165,14 +186,16 @@ const save = () => {
     subExpenses: subExpenses.value.map((item) => ({ ...item })),
   }
 
-  const orderedItems = normalizePriorities([...currentItems, newFutureExpense])
+  const orderedItems = insertFutureExpenseWithPriority(currentItems, newFutureExpense)
 
   if (isEditMode.value) {
-    updateFutureExpense(newFutureExpense)
+    updateFutureExpense({
+      ...newFutureExpense,
+      priority: getPriorityBounded(selectedPriority.value, currentItems.length + 1),
+    })
     setFutureExpenses(orderedItems)
     showSuccess('Actualización exitosa', 'Se ha actualizado tu gasto futuro')
   } else {
-    addFutureExpense(newFutureExpense)
     setFutureExpenses(orderedItems)
     showSuccess('Registro exitoso', 'Se ha registrado tu nuevo gasto futuro')
   }


### PR DESCRIPTION
### Motivation
- Al crear o editar un gasto futuro con una prioridad ya ocupada el nuevo elemento no aparecía correctamente en la lista y las prioridades se reasignaban de forma inesperada.

### Description
- Añadí la función `getPriorityBounded` para acotar prioridades dentro del rango válido y evitar valores fuera de rango.
- Añadí `insertFutureExpenseWithPriority` que desplaza prioridades existentes cuando se inserta un nuevo gasto en una prioridad ocupada y luego normaliza el listado.
- Cambié el flujo de guardado para usar solo `setFutureExpenses` con la lista reordenada y eliminar la inserción duplicada que mezclaba `addFutureExpense` y `setFutureExpenses` para mantener el estado UI consistente.
- Archivo modificado: `src/views/FutureExpensesView.vue` (se añadieron helpers y se ajustó la lógica en la función `save`).

### Testing
- Ejecuté `npm run type-check` y pasó correctamente.
- Ejecuté `npm run lint` y falló por errores preexistentes no relacionados en `src/main.ts`, `src/types.ts` y `src/utils.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddb1adf8088321ae0f83013243e136)