### PR TITLE
Add debounced search filter and move 'New' buttons above tables

### DIFF
--- a/src/hooks/useSearchFilter.ts
+++ b/src/hooks/useSearchFilter.ts
@@ -1,14 +1,32 @@
-import { ref, computed, type Ref } from 'vue'
+import { ref, computed, watch, type Ref } from 'vue'
 
-export default function useSearchFilter<T>(items: Ref<T[]>) {
+const DEFAULT_DEBOUNCE_TIME = 300
+
+export default function useSearchFilter<T>(
+  items: Ref<T[]>,
+  debounceTime = DEFAULT_DEBOUNCE_TIME,
+) {
   const searchText = ref('')
+  const debouncedSearchText = ref('')
+
+  let debounceTimeout: ReturnType<typeof setTimeout> | null = null
+
+  watch(searchText, (value) => {
+    if (debounceTimeout) {
+      clearTimeout(debounceTimeout)
+    }
+
+    debounceTimeout = setTimeout(() => {
+      debouncedSearchText.value = value
+    }, debounceTime)
+  })
 
   const filteredItems = computed(() => {
-    if (!searchText.value) {
+    if (!debouncedSearchText.value) {
       return items.value
     }
 
-    const term = searchText.value.toLowerCase()
+    const term = debouncedSearchText.value.toLowerCase()
     return items.value.filter(item => {
       return JSON.stringify(item).toLowerCase().includes(term)
     })

--- a/src/views/DebtsView.vue
+++ b/src/views/DebtsView.vue
@@ -199,11 +199,11 @@ const save = () => {
 
   <Divider />
 
-  <div class="grid grid-flow-col items-center mb-4 gap-2">
-    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
-    <div>
+  <div class="mb-4">
+    <div class="flex justify-end mb-2">
       <Button label="Nueva Deuda" icon="pi pi-plus" @click="openCreateModal" />
     </div>
+    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
   </div>
 
   <div class="mb-4">

--- a/src/views/ExpensesView.vue
+++ b/src/views/ExpensesView.vue
@@ -216,11 +216,11 @@ const save = () => {
 
   <Divider />
   
-  <div class="grid grid-flow-col items-center mb-4 gap-2">
-    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
-    <div>
+  <div class="mb-4">
+    <div class="flex justify-end mb-2">
       <Button label="Nuevo Gasto" icon="pi pi-plus" @click="openCreateModal" />
     </div>
+    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
   </div>
 
   <div class="mb-4">

--- a/src/views/FutureExpensesView.vue
+++ b/src/views/FutureExpensesView.vue
@@ -221,11 +221,11 @@ const getTotalByExpense = (futureExpense: IFutureExpense) => {
 
   <Divider />
 
-  <div class="grid grid-flow-col items-center mb-4 gap-2">
-    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
-    <div>
+  <div class="mb-4">
+    <div class="flex justify-end mb-2">
       <Button label="Nuevo gasto futuro" icon="pi pi-plus" @click="openCreateModal" />
     </div>
+    <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
   </div>
 
   <div class="mb-4">

--- a/src/views/IncomesView.vue
+++ b/src/views/IncomesView.vue
@@ -206,9 +206,11 @@ const save = () => {
 
   <Divider />
 
-  <div class="grid grid-flow-col items-center mb-4 gap-2">
+  <div class="mb-4">
+    <div class="flex justify-end mb-2">
+      <Button label="Nuevo Ingreso" icon="pi pi-plus" @click="openCreateModal" />
+    </div>
     <InputText v-model="searchText" placeholder="Buscar" class="w-full" />
-    <Button label="Nuevo Ingreso" icon="pi pi-plus" @click="openCreateModal" />
   </div>
 
   <div class="mb-4">


### PR DESCRIPTION
### Motivation

- Reduce excessive filtering while typing by debouncing the search input in the shared hook `useSearchFilter`. 
- Improve UI consistency by moving the list action (`New`/`Nueva`) buttons above the search input and right-aligned in list views. 
- Improve perceived performance for large lists by applying the debounce before computing `filteredItems`.

### Description

- Updated `src/hooks/useSearchFilter.ts` to accept an optional `debounceTime` (default `300`) and added `debouncedSearchText`, a `watch` with `setTimeout`/`clearTimeout`, and switched the computed filter to use `debouncedSearchText` instead of `searchText`.
- Added `DEFAULT_DEBOUNCE_TIME` constant and a `debounceTimeout` local variable in the hook.
- Updated templates in `src/views/DebtsView.vue`, `src/views/ExpensesView.vue`, `src/views/FutureExpensesView.vue`, and `src/views/IncomesView.vue` to move the `Button` into a `div` above the `InputText`, using a `flex justify-end` wrapper so the action button is right-aligned and the search input stays full width below it.

### Testing

- Ran unit tests with `npm run test:unit` and they passed. 
- Ran linter with `npm run lint` and it passed. 
- Performed type checking / build with `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc89b5174832189a3d5de7cbe92da)